### PR TITLE
Standardize name for RIT

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -532,7 +532,7 @@ landscape:
             logo: red-hat.svg
             crunchbase: https://www.crunchbase.com/organization/red-hat
           - item:
-            name: RIT (Adopter)
+            name: Rochester Institute of Technology (Adopter)
             homepage_url: https://www.rit.edu/about-rit
             logo: rochester-institute-of-technology.svg
             crunchbase: https://www.crunchbase.com/organization/rochester-institute-of-technology


### PR DESCRIPTION
I've gone with the longer name, which matches the name in the member section.
