### PR TITLE
Integrate script that will keep the member list up to date

### DIFF
--- a/.github/workflows/autocommit.yml
+++ b/.github/workflows/autocommit.yml
@@ -1,0 +1,19 @@
+name: Autocommit pull requests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Automerge Pull Request if possible
+        uses: "pascalgn/automerge-action@v0.13.0"
+        env:
+          GITHUB_TOKEN: "${{ secrets.PAT }}"
+          MERGE_LABELS: "automerge"
+          MERGE_RETRY_SLEEP: 300000
+          MERGE_METHOD: "squash"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Update members
+
+on:
+  workflow_dispatch:
+  schedule: 
+    - cron:  '0 1 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout landscape
+        uses: actions/checkout@v2
+        with:
+          path: main
+      - name: Checkout landscape-tools
+        uses: actions/checkout@v2
+        with:
+          repository: jmertic/landscape-tools
+          path: landscape-tools
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r landscape-tools/requirements.txt
+      - name: Run build
+        working-directory: ./main
+        env:
+          SF_USERNAME: ${{ secrets.SF_USERNAME }}
+          SF_PASSWORD: ${{ secrets.SF_PASSWORD }}
+          SF_TOKEN: ${{ secrets.SF_TOKEN }}
+        run: |
+          ../landscape-tools/landscapemembers.py
+      - name: Save missing.csv file
+        uses: actions/upload-artifact@v2
+        with:
+          name: missing-members 
+          path: ./main/missing.csv
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.PAT }}
+          branch-suffix: timestamp
+          path: ./main
+          title: Member update
+          labels: member-update
+          commit-message: Member update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,6 @@ jobs:
           token: ${{ secrets.PAT }}
           branch-suffix: timestamp
           path: ./main
-          title: Member update
-          labels: member-update
-          commit-message: Member update
+          title: Update members
+          labels: automated-build
+          commit-message: Update members

--- a/.github/workflows/marksuccessfulbuild.yml
+++ b/.github/workflows/marksuccessfulbuild.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: Amwam/issue-comment-action@v1.3.1
-        if: ${{ github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'member-update') }}
+        if: ${{ github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'automated-build') }}
         with:
           keywords: '["Deploy preview for *ospolandscape* ready"]'
           labels: '["automerge"]'

--- a/.github/workflows/marksuccessfulbuild.yml
+++ b/.github/workflows/marksuccessfulbuild.yml
@@ -1,0 +1,16 @@
+name: "Set Issue Label on successful build"
+on:
+  workflow_dispatch:
+  issue_comment:
+    types: [created]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Amwam/issue-comment-action@v1.3.1
+        if: ${{ github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'member-update') }}
+        with:
+          keywords: '["Deploy preview for *ospolandscape* ready"]'
+          labels: '["automerge"]'
+          github-token: "${{ secrets.PAT }}"

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,8 @@
+landscapeName: ospo
+landscapeMemberClasses:
+   - name: General Membership
+     category: General
+project: a0941000002wBzFAAU # TODO Group
+landscapeMemberCategory: TODO Group Member
+landscapefile: landscape.yml
+missingcsvfile: missing.csv


### PR DESCRIPTION
There are a few things needed in the config to make this work....

1) Add the pre-requisites listed at https://github.com/jmertic/landscape-tools/blob/master/INSTRUCTIONS.md#recommended---automatic-build-with-github-actions
2) Make sure netlify is doing builds on pull requests.

Ping me with questions!

Signed-off-by: John Mertic <jmertic@linuxfoundation.org>

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 250 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~10 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
