### PR TITLE
updated VMware homepage_url 

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -302,7 +302,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/verizon-media
           - item:
             name: VMWare (Member)
-            homepage_url: https://github.com/vmware
+            homepage_url: https://vmware.com/opensource
             logo: vmware.svg
             crunchbase: https://www.crunchbase.com/organization/vmware
           - item:
@@ -663,7 +663,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/verizon-media
           - item:
             name: VMWare (Adopter)
-            homepage_url: https://github.com/vmware
+            homepage_url: https://vmware.com/opensource
             logo: vmware.svg
             crunchbase: https://www.crunchbase.com/organization/vmware
           - item:


### PR DESCRIPTION
I used one that better represents what we do in open source to replace the github org URL that only pointed one of our many GitHub orgs.

Signed-off-by: Dawn M. Foster <fosterd@vmware.com>

