### PR TITLE
change licensing and security subcategory for sca

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -841,7 +841,7 @@ landscape:
             twitter: https://twitter.com/docusaurus
             crunchbase: https://www.crunchbase.com/organization/facebook
       - subcategory:
-        name: Licensing
+        name: SCA
         items:
           - item:
             name: Black Duck
@@ -904,6 +904,31 @@ landscape:
             homepage_url: https://www.whitesourcesoftware.com
             logo: white-source.svg
             crunchbase: https://www.crunchbase.com/organization/white-source
+          - item:
+            name: Debricked Security
+            homepage_url: https://debricked.com/open-source-security
+            logo: debricked.svg
+            crunchbase: https://www.crunchbase.com/organization/debricked
+          - item:
+            name: FOSSA Security Management
+            homepage_url: https://fossa.com/product/open-source-security-management
+            logo: fossa.svg
+            crunchbase: https://www.crunchbase.com/organization/fossa-2
+          - item:
+            name: GitHub Security
+            homepage_url: https://github.com/security
+            logo: github.svg
+            crunchbase: https://www.crunchbase.com/organization/github
+          - item:
+            name: GitLab Secure
+            homepage_url: https://about.gitlab.com/stages-devops-lifecycle/secure/
+            logo: gitlab.svg
+            crunchbase: https://www.crunchbase.com/organization/gitlab-com
+          - item:
+            name: Snyk Open Source Security Management
+            homepage_url: https://snyk.io/product/open-source-security-management
+            logo: snyk.svg
+            crunchbase: https://www.crunchbase.com/organization/snyk
       - subcategory:
         name: Metrics
         items:
@@ -962,31 +987,3 @@ landscape:
             repo_url: https://github.com/todogroup/repolinter
             logo: todo.svg
             crunchbase: https://www.crunchbase.com/organization/todo-group
-      - subcategory:
-        name: Security
-        items:
-          - item:
-            name: Debricked Security
-            homepage_url: https://debricked.com/open-source-security
-            logo: debricked.svg
-            crunchbase: https://www.crunchbase.com/organization/debricked
-          - item:
-            name: FOSSA Security Management
-            homepage_url: https://fossa.com/product/open-source-security-management
-            logo: fossa.svg
-            crunchbase: https://www.crunchbase.com/organization/fossa-2
-          - item:
-            name: GitHub Security
-            homepage_url: https://github.com/security
-            logo: github.svg
-            crunchbase: https://www.crunchbase.com/organization/github
-          - item:
-            name: GitLab Secure
-            homepage_url: https://about.gitlab.com/stages-devops-lifecycle/secure/
-            logo: gitlab.svg
-            crunchbase: https://www.crunchbase.com/organization/gitlab-com
-          - item:
-            name: Snyk Open Source Security Management
-            homepage_url: https://snyk.io/product/open-source-security-management
-            logo: snyk.svg
-            crunchbase: https://www.crunchbase.com/organization/snyk


### PR DESCRIPTION
This commit merges licensing and security subcategories into sca new section

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project closed source or, if it is open source, does your project have at least 250 GitHub stars?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~10 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
