### PR TITLE
Delete ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,0 @@
-### Don't create an issue
-
-If you see an error in the cards or missing ones, please don't create an issue here. Instead, edit landscape.yml (you can even do it via the GitHub web interface) and open a pull request. Then, review the preview staging server that's posted to your pull request and add a comment if your new or updated card looks correct and is ready to merge. Before going forward, please carefully review the sections of the Readme covering new entries, corrections, and logos: https://github.com/cncf/landscape/blob/master/README.md.


### PR DESCRIPTION
I've created a bug-request template that replaces this old issue warning. See: https://github.com/todogroup/ospolandscape/issues/new/choose

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Have you picked the single best (existing) category for your project?
* [ ] If submitting a tool, is your project closed source or, if it is open source, does your project have at least 100 GitHub stars?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [ ] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [ ] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [ ] Does your project/product name match the text on the logo?
* [ ] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [ ] ~10 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
