### PR TITLE
Update BomLens URLs to renamed repository (sktelecom/bomlens)

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -1260,8 +1260,8 @@ landscape:
             description: >-
               BomLens is a local-first, open source SBOM generator and open source risk assessor from SK Telecom. It produces CycloneDX SBOMs and AI ML-BOMs with
               G7 conformance checks, NOTICE files, and security/license risk reports from source, containers, binaries, firmware, AI models, and ingested SBOMs.
-            homepage_url: https://sktelecom.github.io/sbom-tools/
-            repo_url: https://github.com/sktelecom/sbom-tools
+            homepage_url: https://sktelecom.github.io/bomlens/
+            repo_url: https://github.com/sktelecom/bomlens
             logo: bomlens.svg
             crunchbase: https://www.crunchbase.com/organization/sk-telecom
           - item:


### PR DESCRIPTION
The BomLens repository was renamed from `sktelecom/sbom-tools` to `sktelecom/bomlens`. This updates `homepage_url` and `repo_url` for the BomLens entry in `landscape.yml`. The old URLs still 301-redirect, but the direct links are clearer.